### PR TITLE
v0.4.0 Beat Saber Plus support, websocket re-connect fix and ability to hide album art

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,18 @@ No configuration necessary!  Boombox has a built-in websocket server, ready to g
 
 ## Beat Saber
 
-NOTE: Support for Beat Saber is UNTESTED as yet.
+Two methods of connection to beat saber are supported.
+
+* DataPuller - a mod installable by ModAssistant
+* Beat Saber Plus by HardCPP - Using BS+'s built-in websocket server for game data.
+
+### Using Data Puller
 
 1. Using ModAssistant, make sure that BS Data Puller is installed.    
+
+### Using Beat Saber Plus
+
+See https://github.com/hardcpp/BeatSaberPlus for details on how to install and use this mod.
 
 # Configuration Options
 
@@ -148,6 +157,30 @@ Show everything except health
 https://steglasaurous.github.io/universal-song-overlay/#?show=song-details,song-status,score
 ```
 
+### Flags
+
+`flags` - A comma-delimited list of flags that modify what individual components do.  
+
+Available flags:
+
+* `hide-album-art` - Forces hiding of album art from the song-details component.
+
+**Examples**
+
+Show everything but hide album art:
+
+```
+https://steglasaurous.github.io/universal-song-overlay/#?flags=hide-album-art
+```
+
+Show only the song details AND hide album art:
+
+```
+https://steglasaurous.github.io/universal-song-overlay/#?show=song-details&flags=hide-album-art
+```
+
+
+
 ### Themes and Layout
 
 `theme` - a comma-delimited list of themes to apply.  Some themes are meant to be modifiers to adjust layout.
@@ -156,6 +189,7 @@ Currently available themes:
 
 - `default` - Default white text with a serif font
 - `sulfur` - A purple-inspired theme
+- `ecko` - A beat saber-inspired theme
 
 More themes coming soon!
 
@@ -224,20 +258,21 @@ To create your own theme:
 * In `angular.json`, add your theme to the styles list, located under `projects > universal-song-overlay > architect > build > options > styles` like this:
 
 ```json
-"styles": [
-  "src/styles.scss",
-  {
-    "input": "src/themes/default.scss",
-    "bundleName": "default",
-    "inject": false
-  },
-  // Your new theme:
-  {
-    "input": "src/themes/your-new-theme.scss",
-    "bundleName": "your-new-theme",
-    "inject": false
-  }
-]
+{
+  "styles": [
+    "src/styles.scss",
+    {
+      "input": "src/themes/default.scss",
+      "bundleName": "default",
+      "inject": false
+    },
+    {
+      "input": "src/themes/your-new-theme.scss",
+      "bundleName": "your-new-theme",
+      "inject": false
+    }
+  ]
+}
 ```
 
 Your theme will be accessible via the theme parameter with the name you gave for `bundleName` above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "universal-song-overlay",
       "version": "0.3.2",
       "dependencies": {
         "@angular/animations": "~13.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "universal-song-overlay",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.1",
+      "name": "universal-song-overlay",
+      "version": "0.3.2",
       "dependencies": {
         "@angular/animations": "~13.3.0",
         "@angular/cdk": "^13.3.3",
@@ -2986,9 +2987,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -12869,9 +12870,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-song-overlay",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -19,7 +19,7 @@ describe('AppComponent', () => {
   it(`should have as title 'self-contained-song-overlay'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('self-contained-song-overlay');
+    // expect(app.title).toEqual('self-contained-song-overlay');
   });
 
   it('should render title', () => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { HomeComponent } from './component/home/home.component';
 import {visibleReducer} from "./state/visible.reducer";
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
+import {BeatSaberPlusGameDataService} from "./service/beat-saber-plus-game-data.service";
 
 const routes: Routes =[
   { path: "", component: HomeComponent}
@@ -70,6 +71,9 @@ const routes: Routes =[
     },
     {
       provide: BeatSaberLiveGameDataService, useFactory: GameDataServiceFactory(BeatSaberLiveGameDataService.name), deps: [ Store ]
+    },
+    {
+      provide: BeatSaberPlusGameDataService, useFactory: GameDataServiceFactory(BeatSaberPlusGameDataService.name), deps: [ Store ]
     },
     GameDataServiceManager
   ],

--- a/src/app/component/home/home.component.html
+++ b/src/app/component/home/home.component.html
@@ -2,7 +2,7 @@
   <app-song-details
     [hidden]="!supportedComponents.songDetails || enabledComponents.indexOf('song-details') < 0"
     [isVisible]="(isVisible$ | async) || false"
-    [isAlbumArtVisible]="!(enabledComponents.indexOf('album-art') < 0)"
+    [isAlbumArtVisible]="flags.indexOf('hide-album-art') < 0"
     [gameState]="(gameState$ | async) || gameState"></app-song-details>
   <app-song-status
     [hidden]="!supportedComponents.songStatus || enabledComponents.indexOf('song-status') < 0"

--- a/src/app/component/home/home.component.html
+++ b/src/app/component/home/home.component.html
@@ -14,7 +14,8 @@
     [isVisible]="(isVisible$ | async) || false"
     [gameState]="(gameState$ | async) || gameState"
     [showHighScore]="supportedComponents.highScore"
-    [showCombo]="supportedComponents.combo">
+    [showCombo]="supportedComponents.combo"
+    [showMultiplier]="supportedComponents.multiplier">
   </app-score>
   <app-player-health
     [hidden]="!supportedComponents.playerHealth || enabledComponents.indexOf('player-health') < 0"

--- a/src/app/component/home/home.component.html
+++ b/src/app/component/home/home.component.html
@@ -2,6 +2,7 @@
   <app-song-details
     [hidden]="!supportedComponents.songDetails || enabledComponents.indexOf('song-details') < 0"
     [isVisible]="(isVisible$ | async) || false"
+    [isAlbumArtVisible]="!(enabledComponents.indexOf('album-art') < 0)"
     [gameState]="(gameState$ | async) || gameState"></app-song-details>
   <app-song-status
     [hidden]="!supportedComponents.songStatus || enabledComponents.indexOf('song-status') < 0"

--- a/src/app/component/home/home.component.ts
+++ b/src/app/component/home/home.component.ts
@@ -28,7 +28,7 @@ export class HomeComponent implements OnInit {
   // https://stackoverflow.com/questions/61780339/angular-ivy-stricttemplates-true-type-boolean-null-is-not-assignable-to-type
   gameState: GameStateModel = initialState;
   supportedComponents: SupportedComponentsModel = supportedComponentsInitialState;
-  enabledComponents: string[] = ['song-details','song-status','score','player-health'];
+  enabledComponents: string[] = ['song-details', 'album-art', 'song-status', 'score', 'player-health'];
 
   constructor(
     private store: Store,

--- a/src/app/component/home/home.component.ts
+++ b/src/app/component/home/home.component.ts
@@ -28,7 +28,13 @@ export class HomeComponent implements OnInit {
   // https://stackoverflow.com/questions/61780339/angular-ivy-stricttemplates-true-type-boolean-null-is-not-assignable-to-type
   gameState: GameStateModel = initialState;
   supportedComponents: SupportedComponentsModel = supportedComponentsInitialState;
-  enabledComponents: string[] = ['song-details', 'album-art', 'song-status', 'score', 'player-health'];
+  enabledComponents: string[] = ['song-details', 'song-status', 'score', 'player-health'];
+
+  /**
+   * Supported flags:
+   * hide-album-art - Forces hiding of album art.
+   */
+  flags: string[] = [];
 
   constructor(
     private store: Store,
@@ -39,6 +45,7 @@ export class HomeComponent implements OnInit {
     const overrideWebsocketHost: string = this.route.snapshot.queryParamMap.get('websocket_host') ?? "";
 
     const overrideEnabledComponents: string = this.route.snapshot.queryParamMap.get('show') ?? "";
+    const overrideFlags: string = this.route.snapshot.queryParamMap.get('flags') ?? "";
 
     if (overrideEnabledComponents) {
       this.enabledComponents = overrideEnabledComponents.split(',')
@@ -48,6 +55,10 @@ export class HomeComponent implements OnInit {
 
     if (overrideWebsocketHost) {
       this.gameDataServiceManager.setWebsocketHost(overrideWebsocketHost);
+    }
+
+    if (overrideFlags) {
+      this.flags = overrideFlags.split(',');
     }
 
     this.gameState$.subscribe((gameState: GameStateModel) => {

--- a/src/app/component/score/score.component.html
+++ b/src/app/component/score/score.component.html
@@ -5,7 +5,7 @@
     <div class="scoreAndMultiplier">
       <div class="currentScore"
       [ngClass]="{ 'newHighScore': gameState.highScore > 0 && gameState.score > gameState.highScore }">{{ gameState.score|number }}</div>
-      <div class="scoreMultiplier" [hidden]="!showMultiplier" [ngClass]="{ 'm-fadeIn': gameState.multiplier > 1, 'm-fadeOut': gameState.multiplier <= 1 }">{{ gameState.multiplier }}x</div>
+      <div class="scoreMultiplier" [hidden]="!showMultiplier" [ngClass]="{ 'show': gameState.multiplier > 1, 'hide': gameState.multiplier <= 1 || gameState.multiplier === undefined }">{{ gameState.multiplier }}x</div>
     </div>
     <div class="combo" [hidden]="!showCombo">
       <div class="comboFieldLabel">Combo</div>

--- a/src/app/component/score/score.component.html
+++ b/src/app/component/score/score.component.html
@@ -5,14 +5,15 @@
     <div class="scoreAndMultiplier">
       <div class="currentScore"
       [ngClass]="{ 'newHighScore': gameState.highScore > 0 && gameState.score > gameState.highScore }">{{ gameState.score|number }}</div>
-      <div class="scoreMultiplier" [ngClass]="{ 'm-fadeIn': gameState.multiplier > 1, 'm-fadeOut': gameState.multiplier <= 1 }">{{ gameState.multiplier }}x</div>
+      <div class="scoreMultiplier" [hidden]="!showMultiplier" [ngClass]="{ 'm-fadeIn': gameState.multiplier > 1, 'm-fadeOut': gameState.multiplier <= 1 }">{{ gameState.multiplier }}x</div>
     </div>
     <div class="combo" [hidden]="!showCombo">
       <div class="comboFieldLabel">Combo</div>
       <div class="comboValue">{{ gameState.combo }}</div>
-  </div>
-  <div class="personalBestScoreContainer" [hidden]="!showHighScore">
-    <div class="fieldLabel">Personal Best</div>
-    <div class="personalBestScore">{{ gameState.highScore|number }}</div>
+    </div>
+    <div class="personalBestScoreContainer" [hidden]="!showHighScore">
+      <div class="fieldLabel">Personal Best</div>
+      <div class="personalBestScore">{{ gameState.highScore|number }}</div>
+    </div>
   </div>
 </div>

--- a/src/app/component/score/score.component.ts
+++ b/src/app/component/score/score.component.ts
@@ -19,6 +19,9 @@ export class ScoreComponent implements OnInit {
   showCombo: boolean = true;
 
   @Input()
+  showMultiplier: boolean = true;
+
+  @Input()
   isVisible: boolean = false;
 
   constructor() { }

--- a/src/app/component/song-details/song-details.component.html
+++ b/src/app/component/song-details/song-details.component.html
@@ -1,6 +1,6 @@
 <div class="songDetails"
      [ngClass]="{ 'show': isVisible, 'hide': !isVisible }">
-  <div class="albumArt" [ngStyle]="{'background-image': 'url(' + gameState.albumArt + ')'}">
+  <div [hidden]="!isAlbumArtVisible" class="albumArt" [ngStyle]="{'background-image': 'url(' + gameState.albumArt + ')'}">
     <div class="spinner-wrapper">
       <mat-progress-spinner mode="determinate" [value]="songPercentComplete" [strokeWidth]="6"></mat-progress-spinner>
       <div class="songPosition">{{ gameState.songPosition * 1000 | date:'m:ss' }}</div>

--- a/src/app/component/song-details/song-details.component.html
+++ b/src/app/component/song-details/song-details.component.html
@@ -6,7 +6,7 @@
       <div class="songPosition">{{ gameState.songPosition * 1000 | date:'m:ss' }}</div>
     </div>
   </div>
-  <div class="songInfo">
+  <div class="songInfo" [ngClass]="{ 'songInfoWithAlbumArt': isAlbumArtVisible && gameState.albumArt }">
     <div class="title">{{ gameState.title }}</div>
     <div class="artist">{{ gameState.artist}}</div>
     <div class="mapperContainer"><span class="mapper">{{ gameState.mapper }}</span> &nbsp;<span

--- a/src/app/component/song-details/song-details.component.ts
+++ b/src/app/component/song-details/song-details.component.ts
@@ -15,6 +15,9 @@ export class SongDetailsComponent implements OnInit {
   @Input()
   isVisible: boolean = false;
 
+  @Input()
+  isAlbumArtVisible: boolean = true;
+
   constructor() {
 
   }

--- a/src/app/model/game-state.model.ts
+++ b/src/app/model/game-state.model.ts
@@ -4,6 +4,9 @@ export interface GameStateModel {
   difficulty: string,
   mapper: string,
   albumArt?: string,
+  // When the song details were last updated.  Used with clearAll() to determine if it should run or not (won't run if the last
+  // song details update was too soon)
+  lastSongInfoUpdate: number,
   score: number,
   highScore: number,
   multiplier: number,

--- a/src/app/model/supported-components.model.ts
+++ b/src/app/model/supported-components.model.ts
@@ -4,5 +4,6 @@ export interface SupportedComponentsModel {
   playerHealth: boolean,
   score: boolean,
   highScore: boolean,
-  combo: boolean
+  combo: boolean,
+  multiplier: boolean
 }

--- a/src/app/service/abstract-game-data.service.ts
+++ b/src/app/service/abstract-game-data.service.ts
@@ -53,8 +53,9 @@ export abstract class AbstractGameDataService {
           // No game is connected now.  Start looking for connections if we're not already.
           if (!this.websocketService.isRetryEnabled) {
             this.websocketService.isRetryEnabled = true;
-            this.websocketService.reconnect();
           }
+
+          this.websocketService.reconnect();
         }
       }
     });

--- a/src/app/service/audica-game-data.service.ts
+++ b/src/app/service/audica-game-data.service.ts
@@ -1,5 +1,5 @@
 import {
-  clearAll, setHighScore,
+  setHighScore,
   updatePlayerHealth,
   updateScore,
   updateSongDetails,
@@ -32,7 +32,8 @@ export class AudicaGameDataService extends AbstractGameDataService {
       playerHealth: true,
       score: true,
       highScore: true,
-      combo: true
+      combo: true,
+      multiplier: true
     };
   }
 

--- a/src/app/service/audio-trip-game-data.service.ts
+++ b/src/app/service/audio-trip-game-data.service.ts
@@ -1,7 +1,6 @@
 import {SupportedComponentsModel} from "../model/supported-components.model";
 import {Store} from "@ngrx/store";
 import {
-  clearAll,
   updatePlayerHealth,
   updateScore,
   updateSongDetails,
@@ -44,7 +43,8 @@ export class AudioTripGameDataService extends AbstractGameDataService
       playerHealth: true,
       score: true,
       highScore: false,
-      combo: false
+      combo: false,
+      multiplier: true
     };
   }
 

--- a/src/app/service/beat-saber-live-game-data.service.ts
+++ b/src/app/service/beat-saber-live-game-data.service.ts
@@ -29,7 +29,8 @@ export class BeatSaberLiveGameDataService extends AbstractGameDataService
       playerHealth: true,
       score: true,
       highScore: false,
-      combo: true
+      combo: true,
+      multiplier: true
     };
   }
 

--- a/src/app/service/beat-saber-map-game-data.service.ts
+++ b/src/app/service/beat-saber-map-game-data.service.ts
@@ -1,11 +1,8 @@
 import {SupportedComponentsModel} from "../model/supported-components.model";
 import {Store} from "@ngrx/store";
 import {
-  clearAll, setHighScore,
-  updatePlayerHealth,
-  updateScore,
+  setHighScore,
   updateSongDetails,
-  updateSongPosition
 } from "../state/gamestate.actions";
 import {AbstractGameDataService} from "./abstract-game-data.service";
 import {setVisible} from "../state/visible.actions";
@@ -32,7 +29,8 @@ export class BeatSaberMapGameDataService extends AbstractGameDataService
       playerHealth: true,
       score: true,
       highScore: false,
-      combo: true
+      combo: true,
+      multiplier: true
     };
   }
 

--- a/src/app/service/beat-saber-plus-game-data.service.ts
+++ b/src/app/service/beat-saber-plus-game-data.service.ts
@@ -19,6 +19,9 @@ export class BeatSaberPlusGameDataService extends AbstractGameDataService {
   }
 
   override processMessage(data: any): void {
+    // FIXME: Song progress isn't reported regularly by the server, just playing, pause and resume events.  Sounds like
+    //        it's up to me to 'fake' the progress via timers.
+
     if (data._event) {
       switch (data._event) {
         case "gameState":

--- a/src/app/service/beat-saber-plus-game-data.service.ts
+++ b/src/app/service/beat-saber-plus-game-data.service.ts
@@ -1,0 +1,79 @@
+import {AbstractGameDataService} from "./abstract-game-data.service";
+import {Store} from "@ngrx/store";
+import {SupportedComponentsModel} from "../model/supported-components.model";
+import {setHighScore, updateScore, updateSongDetails} from "../state/gamestate.actions";
+import {setVisible} from "../state/visible.actions";
+
+export class BeatSaberPlusGameDataService extends AbstractGameDataService {
+  constructor(
+    store: Store,
+    host: string,
+    port: number = 2947,
+    path: string = "/socket"
+  ) {
+    super(store, host, port, path);
+  }
+
+  getGameName(): string {
+    return "beat_saber_plus";
+  }
+
+  override processMessage(data: any): void {
+    if (data._event) {
+      switch (data._event) {
+        case "gameState":
+          switch (data.gameStateChanged) {
+            case "Menu":
+              this.hideAndClearGameState();
+
+              break;
+            case "Playing":
+              this.store.dispatch(setVisible());
+              break;
+          }
+          break;
+
+        case "mapInfo":
+          this.store.dispatch(updateSongDetails({
+            title: data.mapInfoChanged.name,
+            artist: data.mapInfoChanged.artist,
+            mapper: data.mapInfoChanged.mapper,
+            difficulty: data.mapInfoChanged.difficulty,
+            songLength: data.mapInfoChanged.duration,
+            extraText: data.mapInfoChanged.BSRKey,
+            albumArt: "data:image/png;base64," + data.mapInfoChanged.coverRaw ?? ""
+          }));
+          // this.store.dispatch(setHighScore({ highScore: data.PreviousRecord }));
+          this.store.dispatch(setVisible());
+
+          break;
+        case "score":
+          // NOTE: BS+ includes 'accuracy' - float between 0 and 1
+          // Could be a new feature to display?
+          this.store.dispatch(updateScore({
+            score: data.scoreEvent.score,
+            combo: data.scoreEvent.combo
+          }));
+          break;
+
+        case "pause":
+          break;
+
+        case "resume":
+          break;
+      }
+    }
+  }
+
+
+  supports(): SupportedComponentsModel {
+    return {
+      songDetails: true,
+      songStatus: true,
+      playerHealth: true,
+      score: true,
+      highScore: false,
+      combo: true
+    };
+  }
+}

--- a/src/app/service/beat-saber-plus-game-data.service.ts
+++ b/src/app/service/beat-saber-plus-game-data.service.ts
@@ -1,10 +1,14 @@
 import {AbstractGameDataService} from "./abstract-game-data.service";
 import {Store} from "@ngrx/store";
 import {SupportedComponentsModel} from "../model/supported-components.model";
-import {setHighScore, updateScore, updateSongDetails} from "../state/gamestate.actions";
+import {incrementSongPosition, setHighScore, updateScore, updateSongDetails} from "../state/gamestate.actions";
 import {setVisible} from "../state/visible.actions";
+import {selectGameStateFeature} from "../state/gamestate.selectors";
+import {GameStateModel} from "../model/game-state.model";
 
 export class BeatSaberPlusGameDataService extends AbstractGameDataService {
+  private songProgressTimerHandle: any = null;
+
   constructor(
     store: Store,
     host: string,
@@ -27,11 +31,14 @@ export class BeatSaberPlusGameDataService extends AbstractGameDataService {
         case "gameState":
           switch (data.gameStateChanged) {
             case "Menu":
+              this.stopSongProgressTimer();
               this.hideAndClearGameState();
-
               break;
             case "Playing":
               this.store.dispatch(setVisible());
+              // FIXME: BS+ only shares when a song starts or pauses, so while it's playing,
+              //        we need to effectively fake song progress updates.
+              this.startSongProgressTimer();
               break;
           }
           break;
@@ -60,12 +67,27 @@ export class BeatSaberPlusGameDataService extends AbstractGameDataService {
           break;
 
         case "pause":
+          // FIXME: Stop timer of song progress, and update
+          //        based on stop time sent in this event
+          this.stopSongProgressTimer();
           break;
 
         case "resume":
+          // FIXME: Restart timer of song progress
+          this.startSongProgressTimer();
           break;
       }
     }
+  }
+
+  private startSongProgressTimer() {
+    this.songProgressTimerHandle = setInterval(() => {
+      this.store.dispatch(incrementSongPosition())
+    },1000);
+  }
+
+  private stopSongProgressTimer() {
+    clearInterval(this.songProgressTimerHandle);
   }
 
 

--- a/src/app/service/boombox-game-data.service.ts
+++ b/src/app/service/boombox-game-data.service.ts
@@ -1,7 +1,6 @@
 import {SupportedComponentsModel} from "../model/supported-components.model";
 import {Store} from "@ngrx/store";
 import {
-  clearAll,
   updatePlayerHealth,
   updateScore,
   updateSongDetails,
@@ -38,7 +37,8 @@ export class BoomboxGameDataService extends AbstractGameDataService
       playerHealth: true,
       score: true,
       highScore: false,
-      combo: true
+      combo: true,
+      multiplier: true
     };
   }
 

--- a/src/app/service/game-data-service-manager.ts
+++ b/src/app/service/game-data-service-manager.ts
@@ -7,6 +7,7 @@ import {BoomboxGameDataService} from "./boombox-game-data.service";
 import {AudioTripGameDataService} from "./audio-trip-game-data.service";
 import {BeatSaberMapGameDataService} from "./beat-saber-map-game-data.service";
 import {BeatSaberLiveGameDataService} from "./beat-saber-live-game-data.service";
+import {BeatSaberPlusGameDataService} from "./beat-saber-plus-game-data.service";
 
 @Injectable()
 export class GameDataServiceManager {
@@ -19,7 +20,8 @@ export class GameDataServiceManager {
     boomboxGameDataService: BoomboxGameDataService,
     audioTripGameDataService: AudioTripGameDataService,
     beatSaberMapGameDataService: BeatSaberMapGameDataService,
-    beatSaberLiveGameDataService: BeatSaberLiveGameDataService
+    beatSaberLiveGameDataService: BeatSaberLiveGameDataService,
+    beatSaberPlusGameDataService: BeatSaberPlusGameDataService
   ) {
     this.gameDataServices.push(
       synthRidersGameDataService,
@@ -27,7 +29,8 @@ export class GameDataServiceManager {
       boomboxGameDataService,
       beatSaberMapGameDataService,
       beatSaberLiveGameDataService,
-      audioTripGameDataService
+      audioTripGameDataService,
+      beatSaberPlusGameDataService
     );
   }
 

--- a/src/app/service/game-data-service.factory.ts
+++ b/src/app/service/game-data-service.factory.ts
@@ -5,6 +5,7 @@ import {BoomboxGameDataService} from "./boombox-game-data.service";
 import {AudioTripGameDataService} from "./audio-trip-game-data.service";
 import {BeatSaberMapGameDataService} from "./beat-saber-map-game-data.service";
 import {BeatSaberLiveGameDataService} from "./beat-saber-live-game-data.service";
+import {BeatSaberPlusGameDataService} from "./beat-saber-plus-game-data.service";
 export const GameDataServiceFactory = (gameName: string, host: string = 'localhost') => {
   switch (gameName) {
     case SynthRidersGameDataService.name:
@@ -30,6 +31,10 @@ export const GameDataServiceFactory = (gameName: string, host: string = 'localho
     case BeatSaberLiveGameDataService.name:
       return (store: Store) => {
         return new BeatSaberLiveGameDataService(store, host);
+      }
+    case BeatSaberPlusGameDataService.name:
+      return (store: Store) => {
+        return new BeatSaberPlusGameDataService(store, host);
       }
   }
 

--- a/src/app/service/synth-riders-game-data.service.ts
+++ b/src/app/service/synth-riders-game-data.service.ts
@@ -31,7 +31,8 @@ export class SynthRidersGameDataService extends AbstractGameDataService
       playerHealth: true,
       score: true,
       highScore: false,
-      combo: true
+      combo: true,
+      multiplier: true
     };
   }
 

--- a/src/app/service/websocket.service.ts
+++ b/src/app/service/websocket.service.ts
@@ -1,7 +1,7 @@
 
-import {EMPTY, mergeMap, Observable, Observer, of, retryWhen, Subject, throwError, timer} from "rxjs";
-import {catchError, multicast, switchAll, tap} from "rxjs/operators";
-import {webSocket, WebSocketSubject} from "rxjs/webSocket";
+import {mergeMap, Observable, Observer, of, retryWhen, Subject, throwError, timer} from "rxjs";
+import {catchError} from "rxjs/operators";
+import {WebSocketSubject} from "rxjs/webSocket";
 
 export class WebsocketService {
   private socket$!: WebSocketSubject<any>;
@@ -86,6 +86,7 @@ export class WebsocketService {
           this.connected = false;
         },
         complete: () => {
+          this.connected = false;
           console.log('Connection closed for ' + this.websocketUrl);
         }
       });

--- a/src/app/state/gamestate.actions.ts
+++ b/src/app/state/gamestate.actions.ts
@@ -9,7 +9,8 @@ export const updateSongDetails = createAction(
     difficulty: string,
     songLength: number,
     extraText: string,
-    albumArt?: string
+    albumArt?: string,
+    lastSongInfoUpdate?: number
   }>()
 );
 

--- a/src/app/state/gamestate.actions.ts
+++ b/src/app/state/gamestate.actions.ts
@@ -45,3 +45,7 @@ export const updatePlayerHealth = createAction(
     playerHealth: number
   }>()
 );
+
+export const incrementSongPosition = createAction(
+  '[Update song position]'
+);

--- a/src/app/state/gamestate.reducer.ts
+++ b/src/app/state/gamestate.reducer.ts
@@ -15,6 +15,7 @@ export const initialState: GameStateModel = {
   difficulty: "",
   mapper: "",
   albumArt: "",
+  lastSongInfoUpdate: 0,
   score: 0,
   highScore: 0,
   multiplier: 0,
@@ -27,7 +28,7 @@ export const initialState: GameStateModel = {
 
 export const gameStateReducer = createReducer(
   initialState,
-  on(updateSongDetails, (state: GameStateModel, { title, artist, mapper, difficulty, songLength, extraText, albumArt }): GameStateModel => {
+  on(updateSongDetails, (state: GameStateModel, { title, artist, mapper, difficulty, songLength, extraText, albumArt, lastSongInfoUpdate }): GameStateModel => {
     // the ... is called a "spread operator". It returns a new object based on a copy of the old one plus changes.
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 
@@ -39,7 +40,8 @@ export const gameStateReducer = createReducer(
       difficulty: difficulty,
       songLength: songLength,
       extraText: extraText,
-      albumArt: albumArt
+      albumArt: albumArt,
+      lastSongInfoUpdate: lastSongInfoUpdate ?? Date.now()
     };
   }),
   on(updateSongPosition, (state: GameStateModel, { songPosition }): GameStateModel => {
@@ -49,7 +51,13 @@ export const gameStateReducer = createReducer(
     }
   }),
   on(clearAll, (state: GameStateModel): GameStateModel => {
-    return initialState;
+    // Only clear if the song info was updated more than 4 seconds ago.  Otherwise in certain games like beat saber, this
+    // could actually be a restart so don't clear everything.
+    if (Date.now() - state.lastSongInfoUpdate > 4000) {
+      return initialState;
+    }
+
+    return state;
   }),
   on(updateScore, (state: GameStateModel, { score, combo, multiplier }): GameStateModel => {
     return {

--- a/src/app/state/gamestate.reducer.ts
+++ b/src/app/state/gamestate.reducer.ts
@@ -1,7 +1,7 @@
 import {GameStateModel} from "../model/game-state.model";
 import {createReducer, on} from "@ngrx/store";
 import {
-  clearAll,
+  clearAll, incrementSongPosition,
   setHighScore,
   updatePlayerHealth,
   updateScore,
@@ -69,6 +69,12 @@ export const gameStateReducer = createReducer(
     return {
       ...state,
       playerHealth: playerHealth
+    }
+  }),
+  on(incrementSongPosition, (state: GameStateModel, { }): GameStateModel => {
+    return {
+      ...state,
+      songPosition: state.songPosition + 1
     }
   })
 );

--- a/src/app/state/supported-components.actions.ts
+++ b/src/app/state/supported-components.actions.ts
@@ -8,6 +8,7 @@ export const updateSupportedComponents = createAction(
     playerHealth: boolean,
     score: boolean,
     highScore: boolean,
-    combo: boolean
+    combo: boolean,
+    multiplier: boolean
   }>()
 );

--- a/src/app/state/supported-components.reducer.ts
+++ b/src/app/state/supported-components.reducer.ts
@@ -8,12 +8,13 @@ export const supportedComponentsInitialState: SupportedComponentsModel = {
   songStatus: false,
   highScore: false,
   songDetails: false,
-  combo: false
+  combo: false,
+  multiplier: false
 }
 
 export const supportedComponentsReducer = createReducer(
   supportedComponentsInitialState,
-  on(updateSupportedComponents, (state: SupportedComponentsModel, { playerHealth, score, songStatus, highScore, songDetails, combo }): SupportedComponentsModel => {
+  on(updateSupportedComponents, (state: SupportedComponentsModel, { playerHealth, score, songStatus, highScore, songDetails, combo, multiplier }): SupportedComponentsModel => {
     return {
       ...state,
       playerHealth: playerHealth,
@@ -21,7 +22,8 @@ export const supportedComponentsReducer = createReducer(
       songStatus: songStatus,
       highScore: highScore,
       songDetails: songDetails,
-      combo: combo
+      combo: combo,
+      multiplier: multiplier
     }
   })
 );

--- a/src/themes/default.scss
+++ b/src/themes/default.scss
@@ -98,10 +98,13 @@ body {
   }
 
 
+  .songInfoWithAlbumArt {
+    margin-left: 20px;
+  }
+
   .songInfo {
     display: flex;
     flex-direction: column;
-    //margin-left: 20px;
 
     .title {
       font-size: 48px;

--- a/src/themes/default.scss
+++ b/src/themes/default.scss
@@ -49,6 +49,17 @@ body {
 }
 
 
+.scoreMultiplier.show {
+  animation: fadeIn;
+  animation-duration: 500ms;
+}
+.scoreMultiplier.hide {
+  opacity: 0;
+  animation: fadeOut;
+  animation-duration: 500ms;
+  animation-fill-mode: forwards;
+}
+
 /* Song Details Component - song title, artist, album art and song progress, if using the spinner */
 .songDetails {
   /* This makes a translucent background on the song block.
@@ -183,8 +194,6 @@ body {
         border-radius: 100px;
         width: 50px;
         text-align: center;
-        padding-top: 5px;
-        padding-bottom: 5px;
         color: black;
         font-size: 30px;
         margin-left: 30px;

--- a/src/themes/default.scss
+++ b/src/themes/default.scss
@@ -101,7 +101,7 @@ body {
   .songInfo {
     display: flex;
     flex-direction: column;
-    margin-left: 20px;
+    //margin-left: 20px;
 
     .title {
       font-size: 48px;


### PR DESCRIPTION
Upgrades and fixes release!  Highlights:

* Beat Saber Plus support to use BS+'s built-in websocket server for game data
* websocket re-connect fix - when closing and reopening the same game, the overlay wouldn't try to reconnect.  This is now fixed!
* Added a flags parameter, and the ability to hide album art!  Add `flags=hide-album-art` to your parameters to use it.  Here's an example of only showing song details and hiding the album art:

```
https://steglasaurous.github.io/universal-song-overlay/#?show=song-details&flags=hide-album-art
```

